### PR TITLE
Groovy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
             <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.12</version>
+        </dependency>
     </dependencies>
 
     <!-- BUILD PLUGINS -->

--- a/src/main/java/com/github/writethemfirst/approvals/utils/StackUtils.java
+++ b/src/main/java/com/github/writethemfirst/approvals/utils/StackUtils.java
@@ -22,12 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.codehaus.groovy.runtime.StackTraceUtils;
 
-import static java.lang.String.format;
-import static java.lang.Thread.currentThread;
 import static java.util.Arrays.stream;
 
 /**

--- a/src/test/java/com/github/writethemfirst/approvals/utils/GroovyStackUtilsTest.groovy
+++ b/src/test/java/com/github/writethemfirst/approvals/utils/GroovyStackUtilsTest.groovy
@@ -28,7 +28,6 @@ import static com.github.writethemfirst.approvals.utils.StackUtils.callerClass;
 import static com.github.writethemfirst.approvals.utils.StackUtils.callerMethod;
 import static com.github.writethemfirst.approvals.utils.StackUtils.sanitizeClassName;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals
 
 class GroovyStackUtilsTest {
     @Test
@@ -41,6 +40,7 @@ class GroovyStackUtilsTest {
     void methodNameShouldBeEmpty() {
         assertThat(callerMethod(String.class.getName())).isEmpty();
     }
+
 
     @Test
     void methodNameShouldBeTheMethodName() {
@@ -62,7 +62,7 @@ class GroovyStackUtilsTest {
     void sanitizeClassNameInLambda() {
         String className = getClass().getName();
         Stream.of("whatever")
-            .forEach({s -> assertEquals(className, sanitizeClassName(getClass().getName()))});
+            .forEach({s -> assertThat(sanitizeClassName(getClass().getName())).isEqualTo(className)});
     }
 
     @Test

--- a/src/test/java/com/github/writethemfirst/approvals/utils/GroovyStackUtilsTest.groovy
+++ b/src/test/java/com/github/writethemfirst/approvals/utils/GroovyStackUtilsTest.groovy
@@ -17,7 +17,10 @@
  */
 package com.github.writethemfirst.approvals.utils;
 
+import org.codehaus.groovy.runtime.StackTraceUtils
 import org.junit.jupiter.api.Test;
+
+import com.github.writethemfirst.approvals.utils.StackUtilsTest.Utils
 
 import java.util.stream.Stream;
 
@@ -25,9 +28,9 @@ import static com.github.writethemfirst.approvals.utils.StackUtils.callerClass;
 import static com.github.writethemfirst.approvals.utils.StackUtils.callerMethod;
 import static com.github.writethemfirst.approvals.utils.StackUtils.sanitizeClassName;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals
 
-class StackUtilsTest {
+class GroovyStackUtilsTest {
     @Test
     void guessedClassShouldBeTestClass() {
         final String guessed = StackUtils.callerClass(StackUtils.class);
@@ -59,12 +62,12 @@ class StackUtilsTest {
     void sanitizeClassNameInLambda() {
         String className = getClass().getName();
         Stream.of("whatever")
-            .forEach(s -> assertEquals(className, sanitizeClassName(getClass().getName())));
+            .forEach({s -> assertEquals(className, sanitizeClassName(getClass().getName()))});
     }
 
     @Test
     void methodNameShouldNotBeLambda() {
         Stream.of("whatever")
-            .forEach(s -> assertThat(callerMethod(getClass().getName())).contains("methodNameShouldNotBeLambda"));
+            .forEach({s -> assertThat(callerMethod(getClass().getName())).contains("methodNameShouldNotBeLambda")});
     }
 }

--- a/src/test/java/com/github/writethemfirst/approvals/utils/StackUtilsTest.java
+++ b/src/test/java/com/github/writethemfirst/approvals/utils/StackUtilsTest.java
@@ -25,7 +25,6 @@ import static com.github.writethemfirst.approvals.utils.StackUtils.callerClass;
 import static com.github.writethemfirst.approvals.utils.StackUtils.callerMethod;
 import static com.github.writethemfirst.approvals.utils.StackUtils.sanitizeClassName;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StackUtilsTest {
     @Test
@@ -38,6 +37,7 @@ class StackUtilsTest {
     void methodNameShouldBeEmpty() {
         assertThat(callerMethod(String.class.getName())).isEmpty();
     }
+
 
     @Test
     void methodNameShouldBeTheMethodName() {
@@ -59,7 +59,7 @@ class StackUtilsTest {
     void sanitizeClassNameInLambda() {
         String className = getClass().getName();
         Stream.of("whatever")
-            .forEach(s -> assertEquals(className, sanitizeClassName(getClass().getName())));
+            .forEach(s -> assertThat(sanitizeClassName(getClass().getName())).isEqualTo(className));
     }
 
     @Test


### PR DESCRIPTION
This pull request allows approvals to be used with Groovy projects.

Without these changes, the stacktrace is not interpreted correctly and the file paths calculated for the approval files refer to the Approvals class itself and not the test class.

I added a dependency to groovy 2.4.12, because that is the version for the project where I use approvals. Switching to a newer version of the groovy dependency for approvals-java causes my IDE (Eclipse) to have problems with the project that I am testing.